### PR TITLE
change empty logoic

### DIFF
--- a/src/dagster_mssql_bcp/bcp_core/bcp_io_manager_core.py
+++ b/src/dagster_mssql_bcp/bcp_core/bcp_io_manager_core.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from dagster import ConfigurableIOManager, InputContext, OutputContext
+from dagster import ConfigurableIOManager, InputContext, OutputContext, get_dagster_logger
 
 from .asset_schema import AssetSchema
 from .mssql_connection import connect_mssql
@@ -35,7 +35,8 @@ class BCPIOManagerCore(ConfigurableIOManager):
         raise NotImplementedError
 
     def handle_output(self, context: OutputContext, obj):
-        if self.check_empty(obj):
+        if obj is None:
+            get_dagster_logger().info("No data to load")
             return
 
         bcp_manager = self.get_bcp(


### PR DESCRIPTION
changes the logic on load to only check if None.

Idea is if the partition delivers an empty set of data, this is probably the accurate representation and should update that slice of data. 

Current logic wont clear out an existing partition unless there is some sort of incoming data for it, which may not represent the proper data of a given partition