### PR TITLE
Change IO Manager to accept a BCP Resource instead of raw properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ cython_debug/
 .vscode/
 
 tmp*/
+
+.tmp*/

--- a/README.md
+++ b/README.md
@@ -44,19 +44,22 @@ Polars processes as a `LazyFrame`. Either a `DataFrame` or `LazyFrame` can be pr
 
 ```python
 from dagster import asset, Definitions
-from dagster_mssql_bcp import PolarsBCPIOManager
+from dagster_mssql_bcp import PolarsBCPIOManager, PolarsBCPResource
 import polars as pl
 
 io_manager = PolarsBCPIOManager(
-    host="my_mssql_server",
-    database="my_database",
-    user="username",
-    password="password",
-    query_props={
-        "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={"-u": ""},
-    bcp_path="/opt/mssql-tools18/bin/bcp",
+    resource=PolarsBCPResource(
+        host="my_mssql_server",
+        database="my_database",
+        port='1433',
+        username="username",
+        password="password",
+        query_props={
+            "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={"-u": ""},
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+    )
 )
 
 @asset(
@@ -95,20 +98,24 @@ defs = Definitions(
 
 ```python
 from dagster import asset, Definitions
-from dagster_mssql_bcp import PandasBCPIOManager
+from dagster_mssql_bcp import PandasBCPIOManager, PandasBCPResource
 import pandas as pd
 
 io_manager = PandasBCPIOManager(
-    host="my_mssql_server",
-    database="my_database",
-    user="username",
-    password="password",
-    query_props={
-        "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={"-u": ""},
-    bcp_path="/opt/mssql-tools18/bin/bcp",
+    resource=PandasBCPResource(
+        host="my_mssql_server",
+        database="my_database",
+        port='1433',
+        username="username",
+        password="password",
+        query_props={
+            "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={"-u": ""},
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+    )
 )
+
 
 @asset(
     metadata={

--- a/dagster_mssql_bcp_tests/bcp_pandas/test_io_manager.py
+++ b/dagster_mssql_bcp_tests/bcp_pandas/test_io_manager.py
@@ -1,4 +1,5 @@
 from dagster_mssql_bcp.bcp_pandas import pandas_mssql_io_manager
+from dagster_mssql_bcp.bcp_pandas import pandas_mssql_resource
 import os
 
 from contextlib import contextmanager
@@ -46,7 +47,7 @@ class TestPandasBCPIO:
         return db_config
 
     def io(self):
-        return pandas_mssql_io_manager.PandasBCPIOManager(
+        rsc = pandas_mssql_resource.PandasBCPResource(
             host=os.getenv("TARGET_DB__HOST", ""),
             port=os.getenv("TARGET_DB__PORT", "1433"),
             database=os.getenv("TARGET_DB__DATABASE", ""),
@@ -57,6 +58,9 @@ class TestPandasBCPIO:
             },
             bcp_arguments={"-u": ""},
             bcp_path="/opt/mssql-tools18/bin/bcp",
+        )
+        return pandas_mssql_io_manager.PandasBCPIOManager(
+            resource=rsc
         )
 
     def test_handle_output_basic(self):

--- a/dagster_mssql_bcp_tests/bcp_polars/test_resource.py
+++ b/dagster_mssql_bcp_tests/bcp_polars/test_resource.py
@@ -1,0 +1,73 @@
+from dagster_mssql_bcp.bcp_polars import polars_mssql_resource
+import os
+
+from contextlib import contextmanager
+from sqlalchemy import create_engine, URL
+
+import dagster as dg
+import polars as pl
+
+class TestPolarsBCPResource:
+    @contextmanager
+    def connect_mssql(self):
+        config = self.get_database_connection()
+        connection_url = URL(
+            "mssql+pyodbc",
+            username=config.get("username"),
+            password=config.get("password"),
+            host=config.get("host"),
+            port=int(config.get("port", "1433")),
+            database=config.get("database"),
+            query={
+                "driver": "ODBC Driver 18 for SQL Server",
+                "TrustServerCertificate": "yes",
+            },  # type: ignore
+        )
+        with create_engine(
+            connection_url, fast_executemany=True, hide_parameters=True
+        ).begin() as conn:
+            yield conn
+
+    def get_database_connection(self) -> dict[str, str]:
+        db_config = dict(
+            host=os.getenv("TARGET_DB__HOST", ""),
+            port=os.getenv("TARGET_DB__PORT", "1433"),
+            database=os.getenv("TARGET_DB__DATABASE", ""),
+            username=os.getenv("TARGET_DB__USERNAME", ""),
+            password=os.getenv("TARGET_DB__PASSWORD", ""),
+        )
+
+        return db_config
+
+    def io(self):
+        return polars_mssql_resource.PolarsBCPResource(
+            host=os.getenv("TARGET_DB__HOST", ""),
+            port=os.getenv("TARGET_DB__PORT", "1433"),
+            database=os.getenv("TARGET_DB__DATABASE", ""),
+            username=os.getenv("TARGET_DB__USERNAME", ""),
+            password=os.getenv("TARGET_DB__PASSWORD", ""),
+            query_props={
+                "TrustServerCertificate": "yes",
+            },
+            bcp_arguments={"-u": ""},
+            bcp_path="/opt/mssql-tools18/bin/bcp",
+        )
+    
+    def test_io(self):
+        @dg.asset()
+        def my_asset(context, polars_rsc: polars_mssql_resource.PolarsBCPResource):
+            data = pl.DataFrame(
+                {
+                    "b": ["2021-01-01", "2021-01-01"],
+                }
+            )
+
+            polars_rsc.load_bcp(
+                data, 'dbo', 'tst', [{'name': 'b', 'type': 'DATETIME2'}]
+            )
+            return None
+        
+        dg.materialize(
+            [my_asset],
+            resources={'polars_rsc': self.io()}
+        )

--- a/dagster_mssql_bcp_tests/dagster/launcher.py
+++ b/dagster_mssql_bcp_tests/dagster/launcher.py
@@ -1,9 +1,8 @@
 import dagster as dg
-from dagster_mssql_bcp import PolarsBCPIOManager
+from dagster_mssql_bcp import PolarsBCPIOManager, PolarsBCPResource
 import polars as pl
 
-
-io_manager = PolarsBCPIOManager(
+polars_rsc = PolarsBCPResource(
     host=dg.EnvVar("TARGET_DB__HOST"),
     database=dg.EnvVar("TARGET_DB__DATABASE"),
     username=dg.EnvVar("TARGET_DB__USERNAME"),
@@ -15,6 +14,8 @@ io_manager = PolarsBCPIOManager(
     bcp_arguments={"-u": ""},
     bcp_path="/opt/mssql-tools18/bin/bcp",
 )
+
+io_manager = PolarsBCPIOManager(resource=polars_rsc)
 
 
 @dg.asset(
@@ -41,9 +42,26 @@ def my_polars_asset_lazy(context):
     return pl.LazyFrame({"id": [1, 2, 3]})
 
 
+@dg.asset(
+    metadata={
+        "asset_schema": [
+            {"name": "id", "type": "INT"},
+        ],
+        "schema": "my_schema",
+    }
+)
+def my_polars_asset_resource(context, my_polars_resource: PolarsBCPResource):
+    my_polars_resource.load_bcp(
+        data=pl.LazyFrame({"id": [1, 2, 3]}),
+        schema="my_schema",
+        table="polars_resource_test",
+        asset_schema=[
+            {"name": "id", "type": "INT"},
+        ],
+    )
+
+
 defs = dg.Definitions(
-    assets=[my_polars_asset, my_polars_asset_lazy],
-    resources={
-        "io_manager": io_manager,
-    },
+    assets=[my_polars_asset, my_polars_asset_lazy, my_polars_asset_resource],
+    resources={"io_manager": io_manager, "my_polars_resource": polars_rsc},
 )

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -49,6 +49,9 @@ implementing this class requires the following methods:
     Adds a bit column to indicate if that row should take place in the replacement.
     This is used to update the tab and new line removal from a string
 
+### BCP Resource
+
+This should inherit from the BCPResource and the implement class of BCPCore
 
 ## BCP IO Manager
 
@@ -58,7 +61,6 @@ implementing this class requires the following methods:
 
 * `load_input`: Load the data from the input manager.
 * `check_empty`: Check if the data is empty. return bool if empty
-* `get_bcp`: Return the BCP core class to use.
 
 If you need to connect to something like azure for auth, this is a good place to override the `setup_for_execution` function to process your authentication logic before passing the arguments down to the `BCPCore` using the `query_props` and `bcp_arguments`.
 

--- a/docs/io_manager.md
+++ b/docs/io_manager.md
@@ -4,7 +4,9 @@ The IO manager is a custom IO manager that loads data using BCP into MSSQL.
 
 ## Basic Usage
 
-The IO manager requires the following arguments:
+The io manager is used in conjunction with a `BCPResource`. The Resource is a configurable resource, allowing usage outside the io manager.
+
+The BCPResource requires the following arguments:
 
 * `host`: str -> The host of the MSSQL server.
 * `database`: str -> The database to load the data into.
@@ -20,22 +22,26 @@ These are passed through the `query_props` dictionary and `bcp_arguments` dictio
 
 The following example shows connecting using a username and password, trusting the server certificate and setting the path to the BCP tool, as its not on the path.
 
+Once you have the resource implement you can call the IO manager with its property
+
 ```python
-from dagster_mssql_bcp import PandasBCPIOManager
+from dagster_mssql_bcp import PandasBCPIOManager, PandasBCPResource
 
 io_manager = PandasBCPIOManager(
-    host='my_mssql_server',
-    database='my_database',
-    user='username',
-    password='password',
-    query_props={
-                "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={
-        '-u': ''
-    },
-    bcp_path="/opt/mssql-tools18/bin/bcp",
-    staging_database=None
+    resource=PandasBCPResource(
+        host='my_mssql_server',
+        database='my_database',
+        user='username',
+        password='password',
+        query_props={
+                    "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={
+            '-u': ''
+        },
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+        staging_database=None
+    )
 )
 
 {'io_manager': io_manager}

--- a/examples/basic_pandas.py
+++ b/examples/basic_pandas.py
@@ -1,18 +1,22 @@
 from dagster import asset, Definitions
-from dagster_mssql_bcp import PandasBCPIOManager
+from dagster_mssql_bcp import PandasBCPIOManager, PandasBCPResource
 import pandas as pd
 
 io_manager = PandasBCPIOManager(
-    host="my_mssql_server",
-    database="my_database",
-    user="username",
-    password="password",
-    query_props={
-        "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={"-u": ""},
-    bcp_path="/opt/mssql-tools18/bin/bcp",
+    resource=PandasBCPResource(
+        host="my_mssql_server",
+        database="my_database",
+        port='1433',
+        username="username",
+        password="password",
+        query_props={
+            "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={"-u": ""},
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+    )
 )
+
 
 @asset(
     metadata={
@@ -28,7 +32,7 @@ def my_asset(context):
 
 defs = Definitions(
     assets=[my_asset],
-    io_managers={
+    resources={
         "io_manager": io_manager,
     },
 )

--- a/examples/basic_polars.py
+++ b/examples/basic_polars.py
@@ -1,18 +1,22 @@
 from dagster import asset, Definitions
-from dagster_mssql_bcp import PolarsBCPIOManager
+from dagster_mssql_bcp import PolarsBCPIOManager, PolarsBCPResource
 import polars as pl
 
 io_manager = PolarsBCPIOManager(
-    host="my_mssql_server",
-    database="my_database",
-    user="username",
-    password="password",
-    query_props={
-        "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={"-u": ""},
-    bcp_path="/opt/mssql-tools18/bin/bcp",
+    resource=PolarsBCPResource(
+        host="my_mssql_server",
+        database="my_database",
+        port='1433',
+        username="username",
+        password="password",
+        query_props={
+            "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={"-u": ""},
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+    )
 )
+
 
 @asset(
     metadata={
@@ -28,7 +32,7 @@ def my_asset(context):
 
 defs = Definitions(
     assets=[my_asset],
-    io_managers={
+    resources={
         "io_manager": io_manager,
     },
 )

--- a/examples/time_partition.py
+++ b/examples/time_partition.py
@@ -1,18 +1,22 @@
 from dagster import asset, Definitions, DailyPartitionsDefinition
-from dagster_mssql_bcp import PolarsBCPIOManager
+from dagster_mssql_bcp import PolarsBCPIOManager, PolarsBCPResource
 import polars as pl
 
 io_manager = PolarsBCPIOManager(
-    host="my_mssql_server",
-    database="my_database",
-    user="username",
-    password="password",
-    query_props={
-        "TrustServerCertificate": "yes",
-    },
-    bcp_arguments={"-u": ""},
-    bcp_path="/opt/mssql-tools18/bin/bcp",
+    resource=PolarsBCPResource(
+        host="my_mssql_server",
+        database="my_database",
+        port="1433",
+        username="username",
+        password="password",
+        query_props={
+            "TrustServerCertificate": "yes",
+        },
+        bcp_arguments={"-u": ""},
+        bcp_path="/opt/mssql-tools18/bin/bcp",
+    )
 )
+
 
 @asset(
     metadata={
@@ -21,17 +25,19 @@ io_manager = PolarsBCPIOManager(
             {"name": "datetime_column", "type": "DATETIME2"},
         ],
         "schema": "my_schema",
-        "partition_expr": "datetime_column"
+        "partition_expr": "datetime_column",
     },
     partition=DailyPartitionsDefinition(start_date="2022-01-01", end_date="2022-01-03"),
 )
 def my_asset(context):
-    return pl.DataFrame({"id": [1, 2, 3], "datetime_column": ["2022-01-01", "2022-01-01", "2022-01-01"]})
+    return pl.DataFrame(
+        {"id": [1, 2, 3], "datetime_column": ["2022-01-01", "2022-01-01", "2022-01-01"]}
+    )
 
 
 defs = Definitions(
     assets=[my_asset],
-    io_managers={
+    resources={
         "io_manager": io_manager,
     },
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagster-mssql-bcp"
-version = "0.0.16"
+version = "0.1.0"
 dependencies = [
     "dagster",
     "pendulum",

--- a/src/dagster_mssql_bcp/__init__.py
+++ b/src/dagster_mssql_bcp/__init__.py
@@ -1,12 +1,14 @@
-from dagster_mssql_bcp.bcp_polars import PolarsBCPIOManager, PolarsBCP
-from dagster_mssql_bcp.bcp_pandas import PandasBCPIOManager, PandasBCP
+from dagster_mssql_bcp.bcp_polars import PolarsBCPIOManager, PolarsBCP, PolarsBCPResource
+from dagster_mssql_bcp.bcp_pandas import PandasBCPIOManager, PandasBCP, PandasBCPResource
 
 from dagster_mssql_bcp.bcp_core import AssetSchema
 
 __all__ = [
     "PolarsBCP",
     "PolarsBCPIOManager",
+    "PolarsBCPResource",
     "PandasBCP",
     "PandasBCPIOManager",
+    "PandasBCPResource",
     "AssetSchema",
 ]

--- a/src/dagster_mssql_bcp/bcp_core/bcp_resource.py
+++ b/src/dagster_mssql_bcp/bcp_core/bcp_resource.py
@@ -1,0 +1,35 @@
+import dagster as dg
+
+from typing import Any
+
+class BCPResource(dg.ConfigurableResource):
+    ...
+    host: str
+    port: str
+    database: str
+
+    username: str | None
+    password: str | None
+
+    query_props: dict[str, Any] = {}
+
+    bcp_arguments: dict[str, str] = {}
+    bcp_path: str | None = None
+
+    driver: str = "ODBC Driver 18 for SQL Server"
+
+    process_datetime: bool = True
+    process_replacements: bool = True
+
+    add_row_hash: bool = True
+    add_load_datetime: bool = True
+    add_load_uuid: bool = True
+
+    row_hash_column_name: str = "row_hash"
+    load_uuid_column_name: str = "load_uuid"
+    load_datetime_column_name: str = "load_datetime"
+
+    _new_line_character: str = "__NEWLINE__"
+    _tab_character: str = "__TAB__"
+
+    staging_database: str | None = None

--- a/src/dagster_mssql_bcp/bcp_core/utils.py
+++ b/src/dagster_mssql_bcp/bcp_core/utils.py
@@ -29,7 +29,7 @@ def calculate_max_chunk(df):
     return max_chunksize
 
 
-def get_select_statement(table: str, schema: str, context, columns: list[str] = None) -> str:
+def get_select_statement(table: str, schema: str, context, columns: list[str] | None = None) -> str:
     where_clause = _partition_where_clause(context)
     if where_clause is None:
         where_clause = ""

--- a/src/dagster_mssql_bcp/bcp_pandas/__init__.py
+++ b/src/dagster_mssql_bcp/bcp_pandas/__init__.py
@@ -1,7 +1,9 @@
 from .pandas_mssql_bcp import PandasBCP
 from .pandas_mssql_io_manager import PandasBCPIOManager
+from .pandas_mssql_resource import PandasBCPResource
 
 __all__ = [
     "PandasBCP",
     "PandasBCPIOManager",
+    "PandasBCPResource"
 ]

--- a/src/dagster_mssql_bcp/bcp_pandas/pandas_mssql_io_manager.py
+++ b/src/dagster_mssql_bcp/bcp_pandas/pandas_mssql_io_manager.py
@@ -8,26 +8,18 @@ try:
 except ImportError:
     has_pandas = False
 
-from dagster_mssql_bcp.bcp_pandas import PandasBCP
-
+from .pandas_mssql_resource import PandasBCPResource
 
 class PandasBCPIOManager(BCPIOManagerCore):
+    resource: PandasBCPResource
+    
     def _read_from_database(self, sql, connection_string):
         df = pd.read_sql(sql=sql, con=connection_string, dtype="str")
         return df
-
-    def get_bcp(
-        self,
-        *args,
-        **kwargs,
-    ) -> PandasBCP:
-        return PandasBCP(
-            *args,
-            **kwargs,
-        )
-
+    
     def check_empty(self, obj):
         if obj is None or obj.empty:
             return True
         else:
             return False
+

--- a/src/dagster_mssql_bcp/bcp_pandas/pandas_mssql_resource.py
+++ b/src/dagster_mssql_bcp/bcp_pandas/pandas_mssql_resource.py
@@ -1,0 +1,5 @@
+from dagster_mssql_bcp.bcp_core.bcp_resource import BCPResource
+from .pandas_mssql_bcp import PandasBCP
+
+class PandasBCPResource(BCPResource, PandasBCP):
+    ...

--- a/src/dagster_mssql_bcp/bcp_polars/__init__.py
+++ b/src/dagster_mssql_bcp/bcp_polars/__init__.py
@@ -1,7 +1,9 @@
 from dagster_mssql_bcp.bcp_polars.polars_mssql_bcp import PolarsBCP
 from dagster_mssql_bcp.bcp_polars.polars_mssql_io_manager import PolarsBCPIOManager
+from dagster_mssql_bcp.bcp_polars.polars_mssql_resource import PolarsBCPResource
 
 __all__ = [
     "PolarsBCP",
     "PolarsBCPIOManager",
+    "PolarsBCPResource"
 ]

--- a/src/dagster_mssql_bcp/bcp_polars/polars_mssql_io_manager.py
+++ b/src/dagster_mssql_bcp/bcp_polars/polars_mssql_io_manager.py
@@ -1,27 +1,18 @@
 from dagster_mssql_bcp.bcp_core import BCPIOManagerCore
-from dagster_mssql_bcp.bcp_polars import PolarsBCP
 
 import polars as pl
-
+from .polars_mssql_resource import PolarsBCPResource
 
 
 class PolarsBCPIOManager(BCPIOManagerCore):
+    resource: PolarsBCPResource
+    
     def _read_from_database(self, sql, connection_string):
         df = pl.read_database_uri(
             query=sql,
             uri=connection_string,
         )
         return df
-
-    def get_bcp(
-        self,
-        *args,
-        **kwargs,
-    ) -> PolarsBCP:
-        return PolarsBCP(
-            *args,
-            **kwargs,
-        )
 
     def check_empty(self, obj):
         if obj is None or obj.is_empty():

--- a/src/dagster_mssql_bcp/bcp_polars/polars_mssql_resource.py
+++ b/src/dagster_mssql_bcp/bcp_polars/polars_mssql_resource.py
@@ -1,0 +1,5 @@
+from dagster_mssql_bcp.bcp_core.bcp_resource import BCPResource
+from .polars_mssql_bcp import PolarsBCP
+
+class PolarsBCPResource(BCPResource, PolarsBCP):
+    ...


### PR DESCRIPTION
Changes behaviour to accept a parameter of a configurable resource, instead of the raw property.

Allows the bcp tooling to be used within asset functions directly without using the io manager.

Closes #57 